### PR TITLE
fix: Title misspelling

### DIFF
--- a/themes/keplerjs/_config.yaml
+++ b/themes/keplerjs/_config.yaml
@@ -2,7 +2,7 @@ logo:
   #nav_mobile: images/logo-apollo-space-left.svg
   #subbrand: images/logo-apollo-subbrands-developers-space.svg
   src: 'images/logo-300.png'
-  title: KepleJs Docs
+  title: KeplerJs Docs
   url: https://docs.keplerjs.io/
 
 favicon: images/favicon.ico


### PR DESCRIPTION
Just stumbled on this… I guess in 6 years no-one noticed that the title of the project is spelt incorrectly in the header?!

<img width="327" alt="image" src="https://user-images.githubusercontent.com/380914/211167981-5d43d0f4-be03-463b-9b70-67fb52419099.png">
